### PR TITLE
Add high resolution XKCD image

### DIFF
--- a/_posts/2014-08-31-git-commit.md
+++ b/_posts/2014-08-31-git-commit.md
@@ -5,7 +5,7 @@ last_modified_at: Fri Feb 3 14:44:16 2017 -0600
 ---
 
 <center>
-  <a href="https://xkcd.com/1296/"><img src="https://imgs.xkcd.com/comics/git_commit.png"/></a>
+  <a href="https://xkcd.com/1296/"><img src="https://imgs.xkcd.com/comics/git_commit_2x.png"/></a>
 </center>
 
 ---

--- a/_posts/2014-08-31-git-commit.md
+++ b/_posts/2014-08-31-git-commit.md
@@ -5,7 +5,7 @@ last_modified_at: Fri Feb 3 14:44:16 2017 -0600
 ---
 
 <center>
-  <a href="https://xkcd.com/1296/"><img src="https://imgs.xkcd.com/comics/git_commit_2x.png"/></a>
+  <a href="https://xkcd.com/1296/"><img src="https://imgs.xkcd.com/comics/git_commit_2x.png" width="439" height="250"/></a>
 </center>
 
 ---


### PR DESCRIPTION
Changes the image url for the XKCD comic to be the high DPI version for readers with high DPI displays.