### PR TITLE
Fix Spring Boot commits example links

### DIFF
--- a/_posts/2014-08-31-git-commit.md
+++ b/_posts/2014-08-31-git-commit.md
@@ -41,7 +41,7 @@ Which would you rather read?
 The former varies in length and form; the latter is concise and consistent.<br>
 The former is what happens by default; the latter never happens by accident.
 
-While many repositories' logs look like the former, there are exceptions. The [Linux kernel](https://github.com/torvalds/linux/commits/master) and [Git itself](https://github.com/git/git/commits/master) are great examples. Look at [Spring Boot](https://github.com/spring-projects/spring-boot/commits/master), or any repository managed by [Tim Pope](https://github.com/tpope/vim-pathogen/commits/master).
+While many repositories' logs look like the former, there are exceptions. The [Linux kernel](https://github.com/torvalds/linux/commits/master) and [Git itself](https://github.com/git/git/commits/master) are great examples. Look at [Spring Boot](https://github.com/spring-projects/spring-boot/commits/main), or any repository managed by [Tim Pope](https://github.com/tpope/vim-pathogen/commits/master).
 
 The contributors to these repositories know that a well-crafted Git commit message is the best way to communicate _context_ about a change to fellow developers (and indeed to their future selves). A diff will tell you _what_ changed, but only the commit message can properly tell you _why_. Peter Hutterer [makes this point](http://who-t.blogspot.co.at/2009/12/on-commit-messages.html) well:
 


### PR DESCRIPTION
The default branch was renamed from `master` to `main`